### PR TITLE
Format OCM clusters API response for human readability

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,10 @@
+FROM registry.redhat.io/ubi9/python-311
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ocm_mcp_server.py ./
+
+CMD ["python", "ocm_mcp_server.py"] 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # ocm-mcp
 
 MCP server for Red Hat OpenShift Cluster Manager
+
+## Running with Podman or Docker
+
+You can run the ocm-mcp server in a container using Podman or Docker. Make sure you have a valid OCM access token, which you can obtain by running `ocm login` and then `ocm token`:
+
+```sh
+ocm login --token=YOUR_OFFLINE_TOKEN
+export OCM_TOKEN=$(ocm token)
+```
+
+Example configuration for running with Podman:
+
+```json
+{
+  "mcpServers": {
+    "ocm-mcp": {
+      "command": "podman",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "OCM_TOKEN",
+        "quay.io/maorfr/ocm-mcp"
+      ],
+      "env": {
+        "OCM_TOKEN": "REDACTED"
+      }
+    }
+  }
+}
+```
+
+Replace `REDACTED` with the value from `ocm token`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # ocm-mcp
+
 MCP server for Red Hat OpenShift Cluster Manager

--- a/ocm_mcp_server.py
+++ b/ocm_mcp_server.py
@@ -1,0 +1,57 @@
+import os
+from typing import Any
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("ocm")
+
+OCM_API_BASE = "https://api.openshift.com"
+
+
+async def make_request(url: str) -> dict[str, Any] | None:
+    token = os.environ["OCM_TOKEN"]
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, headers=headers, timeout=30.0)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            print(e)
+            return None
+
+
+def format_clusters_response(data):
+    if not data or "items" not in data:
+        return "No clusters found or invalid response."
+
+    lines = []
+    for cluster in data["items"]:
+        name = cluster.get("name", "N/A")
+        cid = cluster.get("id", "N/A")
+        api_url = cluster.get("api", {}).get("url", "N/A")
+        console_url = cluster.get("console", {}).get("url", "N/A")
+        lines.append(
+            f"Cluster: {name}\n"
+            f"  ID: {cid}\n"
+            f"  API URL: {api_url}\n"
+            f"  Console URL: {console_url}\n"
+        )
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_clusters(state: str) -> str:
+    url = f"{OCM_API_BASE}/api/clusters_mgmt/v1/clusters"
+    data = await make_request(url)
+
+    formatted = format_clusters_response(data)
+    print(formatted)
+    return formatted
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+httpx
+fastmcp


### PR DESCRIPTION
This PR adds a function to format the OCM clusters API response, making the output human-readable. Instead of printing raw JSON, the output now lists each cluster's name, ID, API URL, and Console URL in a clear format.

- Adds `format_clusters_response` function
- Updates `get_clusters` to use the new formatting

This improves usability for anyone consuming the cluster list output.